### PR TITLE
fix missing dep error in babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "app-config-chain": "^1.0.3",
     "app-module-path": "^1.0.5",
     "babel-core": "^6.3.17",
-    "babel-eslint": "^5.0.0-beta6",
+    "babel-eslint": "6.0.0-beta.2",
     "babel-loader": "^6.2.0",
     "babel-plugin-add-module-exports": "^0.1.1",
     "babel-plugin-react-transform": "^2.0.0-beta1",


### PR DESCRIPTION
missing try/catch on optional dep causes babel-eslint to crash on prior version
